### PR TITLE
Improve perfs replacing reduce by a map call

### DIFF
--- a/src/chain.js
+++ b/src/chain.js
@@ -1,9 +1,8 @@
 const chainMatchers = (matchers, originalMatchers = matchers) => {
-  return Object.keys(matchers).reduce((acc, name) => {
+  const mappedMatchers = Object.keys(matchers).map(name => {
     const matcher = matchers[name];
     if (typeof matcher === 'function') {
       return {
-        ...acc,
         [name]: (...args) => {
           matcher(...args); // run matcher
           return chainMatchers(originalMatchers); // chain the original matchers again
@@ -11,10 +10,10 @@ const chainMatchers = (matchers, originalMatchers = matchers) => {
       };
     }
     return {
-      ...acc,
       [name]: chainMatchers(matcher, originalMatchers) // recurse on .not/.resolves/.rejects
     };
-  }, {});
+  });
+  return Object.assign({}, ...mappedMatchers);
 };
 
 export default expect => {


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
Applying the extend only once at the end increases performances a lot (more than 10x in my example). 

<!-- Why are these changes necessary? Link any related issues -->
### Why
The overhead is still big on expectations but it becomes quite reasonable.
In my example, a test case containing around 30 expectations passed from a duration of 1,518ms to 140ms.

<!-- If necessary add any additional notes on the implementation -->
### Notes
I can provide some screenshots of the gain if needed.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings