### PR TITLE
Support promises and returning matcher from test

### DIFF
--- a/src/chain.test.js
+++ b/src/chain.test.js
@@ -200,4 +200,19 @@ describe('.chain', () => {
 
     expect(() => chain(expectMock)('hello').toBe('hi')).toThrowErrorMatchingInlineSnapshot('"blah"');
   });
+
+  it('can be used as the direct return value for a test function', () =>
+    chain(expect)(3)
+      .toBeGreaterThan(1)
+      .toBeLessThan(5));
+
+  it('can be used with resolves', () =>
+    chain(expect)(Promise.resolve(7))
+      .resolves.toBeLessThan(10)
+      .resolves.not.toBeLessThan(5));
+
+  it('can be used with rejects', () =>
+    chain(expect)(Promise.reject(7))
+      .rejects.toBeLessThan(10)
+      .rejects.not.toBeLessThan(5));
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@ declare namespace jest {
   interface ChainedMatchers<T>
     extends jest.JestMatchersShape<
       Matchers<ChainedMatchers<T>, T>,
-      Matchers<Promise<ChainedMatchers<T>>, T>
+      Matchers<Promise<ChainedMatchers<T>> & ChainedMatchers<T>, T>
     > {}
 
   interface Expect {


### PR DESCRIPTION
### What

Feature: support async returns from matchers

### Why

If you want to use `jest-chain` and you also need to return a `Promise` from your test function.  Without this change, `jest-chain` will throw away all the promises.

### Notes

This makes `jest-chain` always return a promise.  The promise also has all the matchers available on it.  If a matcher in the chain returns a promise, the promise returned by chained matchers will depend on that promise.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings