### PR TITLE
💬 Return original error if error is not caused by matcher.

### DIFF
--- a/src/chain.js
+++ b/src/chain.js
@@ -18,6 +18,8 @@ const chainMatchers = (matchers, originalMatchers = matchers) => {
           matcher(...args); // run matcher
           return chainMatchers(originalMatchers); // chain the original matchers again
         } catch (error) {
+          // in case the error is a runtime error,
+          if (!error.matcherResult) throw error;
           throw new JestAssertionError(error.matcherResult, newMatcher);
         }
       };

--- a/src/chain.test.js
+++ b/src/chain.test.js
@@ -200,4 +200,15 @@ describe('.chain', () => {
 
     expect(() => chain(expectMock)('hello').toBe('hi')).toThrowErrorMatchingInlineSnapshot('"blah"');
   });
+
+  it('throws original error when error is not a failed matcher', () => {
+    expect.assertions(1);
+    const expectMock = jest.fn(() => ({
+      toBe: () => {
+        throw new Error('Original runtime error');
+      }
+    }));
+
+    expect(() => chain(expectMock)('hello').toBe('hi')).toThrowErrorMatchingInlineSnapshot('"Original runtime error"');
+  });
 });


### PR DESCRIPTION
### What
When the catched error is not a failing matcher but a runtime error, it now throws the original error. 

### Why
Before, a runtime error was presented same as a failed matcher. This way, it's faster to see that a runtime error was happening.

### Housekeeping

- [x] Unit tests
- [x] ~~Documentation is up to date~~ (not relevant)